### PR TITLE
Update inverter_class.php

### DIFF
--- a/inverter_class.php
+++ b/inverter_class.php
@@ -87,6 +87,7 @@
 
 	*/
 
+	#[AllowDynamicProperties]
 	class Inverter
 	{
 		public		 	$bytessent		=	0;		// bytes sent to inverter


### PR DESCRIPTION
Prevent error.log messages that start to arrive from  PHP8.2.:

"PHP message: PHP Deprecated:  Creation of dynamic property Inverter::$Method is deprecated
PHP message: PHP Deprecated:  Creation of dynamic property Inverter::$step is deprecated
PHP message: PHP Deprecated:  Creation of dynamic property Inverter::$inverterID is deprecated
PHP Deprecated:  Creation of dynamic property Inverter::$JSON is deprecated